### PR TITLE
Use tksContractUrl variable not hardcoded

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -1,0 +1,24 @@
+/*
+Copyright © 2022 SK Telecom <https://github.com/openinfradev>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+var (
+	defaultContractId string
+	defaultCspId      string
+	tksInfoUrl        string
+	tksClusterLcmUrl  string
+	tksContractUrl    string
+)

--- a/cmd/contract.go
+++ b/cmd/contract.go
@@ -24,8 +24,8 @@ import (
 // contractCmd represents the contract command
 var contractCmd = &cobra.Command{
 	Use:   "contract",
-	Short: "Operation for TACO Contract",
-	Long: `Operation for TACO Contract`,
+	Short: "Operation for TKS Contract",
+	Long:  `Operation for TKS Contract`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("contract called")
 	},

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -72,7 +72,7 @@ tksadmin contract create <CONTRACT NAME>`,
 		quota.FsSsd = 0
 		data[0].Quota = quota
 		data[0].AvailableServices = []string{"LMA", "SERVICE_MESH"}
-		data[0].CspName = "test"
+		data[0].CspName = "aws"
 		m := protojson.MarshalOptions{
 			Indent:        "  ",
 			UseProtoNames: true,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,8 +18,8 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"github.com/spf13/cobra"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
@@ -54,7 +54,7 @@ func init() {
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
 
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.tksadmin-client.yaml)")
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.tks-client.yaml)")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
@@ -74,7 +74,7 @@ func initConfig() {
 		// Search config in home directory with name ".tksadmin-client" (without extension).
 		viper.AddConfigPath(home)
 		viper.SetConfigType("yaml")
-		viper.SetConfigName(".tksadmin-client")
+		viper.SetConfigName(".tks-client")
 	}
 
 	viper.AutomaticEnv() // read in environment variables that match


### PR DESCRIPTION
tks contact service url이 소스코드에 하드코딩되어있는것을 config file에 저장하는 것을 사용하도록 변경
gofmt로 인덴트 검사를 했더니 많은 부분이 들여쓰기 때문에 변경된 것으로 나옵니다.
변경사항: 
cmd/common.go 추가
cmd/create.go 변경

추가로 더이상 사용하지 않는 TACO를 TKS로 변경하였습니다.