### PR TITLE
add go unit test for tks cli

### DIFF
--- a/.github/workflows/golangcic-lint.yml
+++ b/.github/workflows/golangcic-lint.yml
@@ -1,0 +1,41 @@
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - main
+      - 'release**'
+  pull_request:
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Configure git for private modules
+        run: git config --global url."https://x-access-token:${{ secrets.PRV_GITHUB_TOKEN }}@github.com/openinfradev".insteadOf "https://github.com/openinfradev"
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          version: latest
+          args: --timeout=5m
+
+          # Optional: working directory, useful for monorepos
+          # working-directory: somedir
+
+          # Optional: golangci-lint command line arguments.
+          # args: --issues-exit-code=0
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # only-new-issues: true
+
+          # Optional: if set to true then the action will use pre-installed Go.
+          # skip-go-installation: true
+
+          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
+          # skip-pkg-cache: true
+
+          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
+          # skip-build-cache: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,20 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1,13 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue is stale because it has been open 7 days with no activity. Remove stale label or comment or this will be closed in 3 days.'
+          stale-pr-message: 'This PR is stale because it has been open 3 days with no activity. Remove stale label or comment or this will be closed in 3 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stalled for 10 days with no activity.'
+          days-before-issue-stale: 7
+          days-before-pr-stale: 3
+          days-before-issue-close: 3
+          days-before-pr-close: 3 

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,0 +1,29 @@
+on:
+  push:
+    branches:
+      - main
+      - 'release**'
+  pull_request:
+    branches:
+      - main
+      - 'release**'
+jobs:
+    unittest:
+        runs-on: ubuntu-latest
+        steps:
+        - name: Check out repository code
+          uses: actions/checkout@v2
+
+        - name: Configure git for private modules
+          run: git config --global url."https://x-access-token:${{ secrets.PRV_GITHUB_TOKEN }}@github.com/openinfradev".insteadOf "https://github.com/openinfradev"
+
+        - name: Set up Go
+          uses: actions/setup-go@v2
+          with:
+            go-version: 1.17
+
+        - name: Build
+          run: go build -v ./...
+
+        - name: Test
+          run: go test -v -cover ./...


### PR DESCRIPTION
cli에 대한 unit test 수행합니다.
현재 상태는 커버리지를 보여줄 뿐 별다른 제한은 없습니다.
추후 필요하다면 최소 커버리지를 놓고 부족하면 기각하는 기능을 생각해 볼수도 있습니다.
현재 테스트 코드는 tks.v2(예전 서버)기준으로 실 호출을 통한 테스트를 진행하므로 에러가 발생할 수도 있습니다. (이건 테스트 내부에서 수정이 필요함, 목업을 하거나 테스트용 엔드포인트와 생성, 생성부터 확인 및 삭제까지 이어지는 테스트 셑을 작성)