### PR TITLE
Remove os.Exit for testing

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -17,9 +17,9 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
-	"os"
 	"time"
 
 	"google.golang.org/grpc"
@@ -38,18 +38,17 @@ var createCmd = &cobra.Command{
 
 Example:
 tksadmin contract create <CONTRACT NAME>`,
-	Run: func(cmd *cobra.Command, args []string) {
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			fmt.Println("You must specify contract name.")
-			fmt.Println("Usage: tksadmin contract create <CONTRACT NAME>")
-			os.Exit(1)
+			return errors.New("Usage: tksadmin contract create <CONTRACT NAME>")
 		}
 		fmt.Println("Contract Name: ", args[0])
 		var conn *grpc.ClientConn
 		tksContractUrl = viper.GetString("tksContractUrl")
 		if tksContractUrl == "" {
-			fmt.Println("You must specify tksContractUrl at config file")
-			os.Exit(1)
+			return errors.New("You must specify tksContractUrl at config file")
 		}
 		conn, err := grpc.Dial(tksContractUrl, grpc.WithInsecure())
 		if err != nil {
@@ -81,7 +80,13 @@ tksadmin contract create <CONTRACT NAME>`,
 		fmt.Println("Proto Json data...")
 		fmt.Println(string(jsonBytes))
 		r, err := client.CreateContract(ctx, &data[0])
-		fmt.Println(r)
+		if err != nil {
+			return fmt.Errorf("Error: %s", err)
+		} else {
+			fmt.Println("Success: The request to create contract ", args[0], " was accepted.")
+			fmt.Print(r)
+		}
+		return nil
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,7 +44,7 @@ For more: https://github.com/openinfradev/tksadmin-client/`,
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	cobra.CheckErr(rootCmd.Execute())
+	rootCmd.Execute()
 }
 
 func init() {

--- a/cmd/root_cmd_test.go
+++ b/cmd/root_cmd_test.go
@@ -59,8 +59,8 @@ func doTest(t *testing.T, testcases []Testcase) {
 func TestContractCmd(t *testing.T) {
 	testcases := []Testcase{
 		{[]string{"contract"}, true, "", ""},
-		// {[]string{"contract", "create"}, false, "", ""},	// It generates Exit(1) and the FAILed test
-		// {[]string{"contract", "create", "cli-unit-test"}, true, "Contract Name:  cli-unit-test\nYou must specify tksContractUrl at config file", ""}, // It generates Exit(1) and the FAILed test
+		{[]string{"contract", "create"}, true, "Usage: tksadmin contract create <CONTRACT NAME>", ""},
+		{[]string{"contract", "create", "cli-unit-test"}, true, "Contract Name:  cli-unit-test\nYou must specify tksContractUrl at config file", ""},
 	}
 
 	doTest(t, testcases)


### PR DESCRIPTION
기존 소스코드에서 잘못된 Argument 발견시 즉시 종료를 위해 사용한 os.Exit(1)이 unit test시 이 후 테스트를 수행하지 못하고 바로 종료되는 버그가 존재하여 os.Exit(1)이 아닌 errors객체를 사용하도록 변경한 PR입니다.